### PR TITLE
Improve android-ci action

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,30 +13,22 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: set up JDK 11
+      - name: Setup JDK 11
         uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'zulu'
+          
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/buildSrc/**/*.kt') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-      
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+          gradle-home-cache-cleanup: true
       
       - name: Build Gradle
         run: ./gradlew build 
       
       - name: Bulid App 
         run: ./gradlew assembleDebug
-
-      - name: Run Unit Test
-        run: ./gradlew testDebugUnitTest

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,5 +1,8 @@
 name: Android CI
 
+env:
+  GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,9 +5,6 @@ env:
 
 on:
   pull_request:
-    branches:
-      - '*'
-      - 'main'
 
 jobs:
   build:


### PR DESCRIPTION
## Overview

1. set up 을 한 단어로 합쳤습니다.
  <img src="https://user-images.githubusercontent.com/40740128/196710534-145cebad-1a0c-443e-b511-7c5a292adbca.png" width="33%" />

2. 그레이들 캐싱과 권한을 위해 공식 [그레이들 빌드 액션](https://github.com/marketplace/actions/gradle-build-action)을 사용하였습니다.
3. 안드로이드 SDK 를 설정하는 [액션](https://github.com/marketplace/actions/setup-android-sdk-tools)을 추가하였습니다.
4. `./gradlew build` 에 `./gradlew test` 가 포함돼 있기 때문에 별도로 `./gradlew test` 를 진행하는 부분을 제거하였습니다.
5.  할당된 메모리 공간을 4G 로 조정하였습니다.
6. gradle daemon 을 비활성화 하였습니다. 이는 자동화에서 할당된 Worker 가 이전 Job 과 동일한 Worker 라는 보장을 할 수 없기 때문입니다.

---

```
on:
  pull_request:
    branches:
      - '*'
      - 'main'
```

추가로 branch 제한을 와일드카드(`*`) 로 하고 있는데 의도된 부분일까요?