### PR TITLE
BaseUseCase 코드 최적화

### DIFF
--- a/domain/src/main/java/com/dev/playground/domain/usecase/base/CoroutineUseCase.kt
+++ b/domain/src/main/java/com/dev/playground/domain/usecase/base/CoroutineUseCase.kt
@@ -6,18 +6,14 @@ import kotlinx.coroutines.withContext
 abstract class CoroutineUseCase<in P, R>(private val coroutineDispatcher: CoroutineDispatcher) {
 
     suspend operator fun invoke(parameters: P): Result<R> {
-        return try {
+        return runCatching {
             withContext(coroutineDispatcher) {
-                execute(parameters).let {
-                    Result.success(it)
-                }
+                execute(parameters)
             }
-        } catch (e: Exception) {
-            Result.failure(e)
         }
     }
 
-   @Throws(RuntimeException::class)
-   protected abstract suspend fun execute(param: P): R
+    @Throws(RuntimeException::class)
+    protected abstract suspend fun execute(param: P): R
 
 }

--- a/domain/src/main/java/com/dev/playground/domain/usecase/base/NonParamCoroutineUseCase.kt
+++ b/domain/src/main/java/com/dev/playground/domain/usecase/base/NonParamCoroutineUseCase.kt
@@ -6,14 +6,10 @@ import kotlinx.coroutines.withContext
 abstract class NonParamCoroutineUseCase<R>(private val coroutineDispatcher: CoroutineDispatcher) {
 
     suspend operator fun invoke(): Result<R> {
-        return try {
+        return runCatching {
             withContext(coroutineDispatcher) {
-                execute().let {
-                    Result.success(it)
-                }
+                execute()
             }
-        } catch (e: Exception) {
-            Result.failure(e)
         }
     }
 


### PR DESCRIPTION
## What?

수동으로 구현한 부분을 동일한 역할을 하는 코틀린의 내장 함수로 교체 (좀 더 간단한 코드를 위함)

## Changes

기존 BaseUseCase 에서 `Result<R>` 로 래핑하기 위해 `try ~ catch` 로 처리하고 있던 부분을 동일한 역할을 하는 코틀린의 내장 함수인 `runCatching` 으로 변경하였습니다.

## Test Guide

`./gradlew build`

## ⚠️ Warning

`runCatching` 은 catch 를 `Throwable` 로 받고, 기존 코드는 `Exception` 으로 받고 있습니다.
최종적으론 `Result.failure` 에서 `Throwable` 타입으로 캐스팅되는 하나, catch 에서 `Exception` 으로 받는 것이 의도된 동작이라면 의도하신 목적을 여쭙고 싶습니다.

