### PR TITLE
토큰 리프레싱 작업

### DIFF
--- a/data/src/main/java/com/dev/playground/data/data_source/local/SharedPreferencesDataSource.kt
+++ b/data/src/main/java/com/dev/playground/data/data_source/local/SharedPreferencesDataSource.kt
@@ -37,6 +37,12 @@ class SharedPreferencesDataSource(context: Context) {
         }
     }
 
+    fun setAccessToken(accessToken: String) {
+        preferences.edit {
+            putString(KEY_ACCESS_TOKEN, accessToken)
+        }
+    }
+
     fun removeAuth() {
         preferences.edit {
             remove(KEY_ACCESS_TOKEN)

--- a/data/src/main/java/com/dev/playground/data/data_source/remote/AuthService.kt
+++ b/data/src/main/java/com/dev/playground/data/data_source/remote/AuthService.kt
@@ -2,6 +2,7 @@ package com.dev.playground.data.data_source.remote
 
 import com.dev.playground.data.model.AuthData
 import com.dev.playground.data.model.MemberType
+import com.dev.playground.data.model.RefreshedAccessTokenData
 import com.dev.playground.data.model.UserData
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -21,5 +22,8 @@ interface AuthService {
 
     @POST("auth/logout")
     suspend fun postLogout()
+
+    @POST("auth/token/reissue")
+    suspend fun refreshAccessToken(): RefreshedAccessTokenData
 
 }

--- a/data/src/main/java/com/dev/playground/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/dev/playground/data/di/RepositoryModule.kt
@@ -1,20 +1,37 @@
 package com.dev.playground.data.di
 
 import com.dev.playground.data.repository.*
+import com.dev.playground.data.util.AutoTokenRefresher
 import com.dev.playground.domain.repository.*
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val repositoryModule = module {
     single<SharedPreferencesRepository> { SharedPreferencesRepositoryImpl(get()) }
-    single<AuthRepository> { AuthRepositoryImpl(get()) }
-    single<MemoryRepository> { MemoryRepositoryImpl(get()) }
+    single<AuthRepository> {
+        AuthRepositoryImpl(
+            service = get(),
+            refresher = get()
+        )
+    }
+    single<MemoryRepository> {
+        MemoryRepositoryImpl(
+            service = get(),
+            refresher = get()
+        )
+    }
     single<PhotoRepository> { PhotoRepositoryImpl(get()) }
     single<LocationRepository> {
         LocationRepositoryImpl(
             service = get(),
             apiKeyId = get(named(X_NCP_APIGW_API_KEY_ID)),
             apiKey = get(named(X_NCP_APIGW_API_KEY))
+        )
+    }
+    single {
+        AutoTokenRefresher(
+            sharedPreferencesDataSource = get(),
+            service = get()
         )
     }
 }

--- a/data/src/main/java/com/dev/playground/data/model/RefreshedAccessTokenData.kt
+++ b/data/src/main/java/com/dev/playground/data/model/RefreshedAccessTokenData.kt
@@ -1,0 +1,8 @@
+package com.dev.playground.data.model
+
+import com.google.gson.annotations.SerializedName
+
+data class RefreshedAccessTokenData(
+    @SerializedName("access_token")
+    val accessToken: String
+)

--- a/data/src/main/java/com/dev/playground/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/dev/playground/data/repository/AuthRepositoryImpl.kt
@@ -3,17 +3,23 @@ package com.dev.playground.data.repository
 import com.dev.playground.data.data_source.remote.AuthService
 import com.dev.playground.data.model.MemberType
 import com.dev.playground.data.model.toDomain
+import com.dev.playground.data.util.AutoTokenRefresher
 import com.dev.playground.domain.model.User
 import com.dev.playground.domain.repository.AuthRepository
 
-class AuthRepositoryImpl(private val service: AuthService) : AuthRepository {
+class AuthRepositoryImpl(
+    private val service: AuthService,
+    private val refresher: AutoTokenRefresher,
+) : AuthRepository {
 
     override suspend fun requestLogin(memberType: String) = service.requestLogin(MemberType(memberType)).toDomain()
 
-    override suspend fun getUser(): User = service.getUser().toDomain()
+    override suspend fun getUser(): User = refresher.authHandle { service.getUser().toDomain() }
 
-    override suspend fun deleteUser() = service.deleteUser()
+    override suspend fun deleteUser() = refresher.authHandle { service.deleteUser() }
 
-    override suspend fun postLogout() = service.postLogout()
+    override suspend fun postLogout() = refresher.authHandle { service.postLogout() }
+
+    override suspend fun refreshAccessToken(): String = service.refreshAccessToken().accessToken
 
 }

--- a/data/src/main/java/com/dev/playground/data/repository/MemoryRepositoryImpl.kt
+++ b/data/src/main/java/com/dev/playground/data/repository/MemoryRepositoryImpl.kt
@@ -3,16 +3,26 @@ package com.dev.playground.data.repository
 import com.dev.playground.data.data_source.remote.MemoryService
 import com.dev.playground.data.model.MemoryData
 import com.dev.playground.data.model.toDomain
+import com.dev.playground.data.util.AutoTokenRefresher
 import com.dev.playground.domain.model.Memory
 import com.dev.playground.domain.model.MemoryInput
 import com.dev.playground.domain.repository.MemoryRepository
 
-class MemoryRepositoryImpl(private val service: MemoryService) : MemoryRepository {
+class MemoryRepositoryImpl(
+    private val service: MemoryService,
+    private val refresher: AutoTokenRefresher
+) : MemoryRepository {
 
-    override suspend fun getMemoryList(page: Int): List<Memory> = service.getMemoryList(page).map(MemoryData::toDomain)
+    override suspend fun getMemoryList(page: Int): List<Memory> = refresher.authHandle {
+        service.getMemoryList(page).map(MemoryData::toDomain)
+    }
 
-    override suspend fun postMemory(params: MemoryInput): Memory = service.postMemory(params).toDomain()
+    override suspend fun postMemory(params: MemoryInput): Memory = refresher.authHandle {
+        service.postMemory(params).toDomain()
+    }
 
-    override suspend fun deleteMemory(params: Int) = service.deleteMemory(params)
+    override suspend fun deleteMemory(params: Int) = refresher.authHandle {
+        service.deleteMemory(params)
+    }
 
 }

--- a/data/src/main/java/com/dev/playground/data/util/AuthenticationInterceptor.kt
+++ b/data/src/main/java/com/dev/playground/data/util/AuthenticationInterceptor.kt
@@ -1,6 +1,7 @@
 package com.dev.playground.data.util
 
 import com.dev.playground.data.data_source.local.SharedPreferencesDataSource
+import com.dev.playground.domain.exception.NotLoggedInException
 import okhttp3.Interceptor
 import okhttp3.Response
 import java.io.IOException
@@ -15,7 +16,10 @@ class AuthenticationInterceptor(
     }
 
     override fun intercept(chain: Interceptor.Chain): Response = with(chain) {
-        val token = preferencesManager.getToken() ?: throw IOException()
+        val token = preferencesManager.getToken() ?: run {
+            preferencesManager.removeAuth()
+            throw NotLoggedInException()
+        }
         val headerToken = token.getHeaderToken(request().url.encodedPath)
 
         val newRequest = request().newBuilder()

--- a/data/src/main/java/com/dev/playground/data/util/AutoTokenRefresher.kt
+++ b/data/src/main/java/com/dev/playground/data/util/AutoTokenRefresher.kt
@@ -1,0 +1,41 @@
+package com.dev.playground.data.util
+
+import com.dev.playground.data.data_source.local.SharedPreferencesDataSource
+import com.dev.playground.data.data_source.remote.AuthService
+import com.dev.playground.domain.exception.NotLoggedInException
+import retrofit2.HttpException
+import java.net.HttpURLConnection.HTTP_UNAUTHORIZED
+
+class AutoTokenRefresher(
+    private val sharedPreferencesDataSource: SharedPreferencesDataSource,
+    private val service: AuthService,
+) {
+
+    suspend fun <T> authHandle(action: suspend () -> T): T {
+        return try {
+            action.invoke()
+        } catch (e: HttpException) {
+            if (e.isUnAuthorized()) {
+                refreshToken()
+            }
+            action.invoke()
+        }
+    }
+
+    private suspend fun refreshToken() {
+        try {
+            val tokenData = service.refreshAccessToken()
+            sharedPreferencesDataSource.setAccessToken(tokenData.accessToken)
+        } catch (e: HttpException) {
+            if (e.isUnAuthorized()) {
+                sharedPreferencesDataSource.removeAuth()
+                throw NotLoggedInException()
+            } else {
+                throw e
+            }
+        }
+    }
+
+    private fun HttpException.isUnAuthorized(): Boolean = code() == HTTP_UNAUTHORIZED
+
+}

--- a/domain/src/main/java/com/dev/playground/domain/exception/NotLoggedInException.kt
+++ b/domain/src/main/java/com/dev/playground/domain/exception/NotLoggedInException.kt
@@ -1,0 +1,3 @@
+package com.dev.playground.domain.exception
+
+class NotLoggedInException: Exception()

--- a/domain/src/main/java/com/dev/playground/domain/model/Token.kt
+++ b/domain/src/main/java/com/dev/playground/domain/model/Token.kt
@@ -14,6 +14,7 @@ data class Token(
     private enum class NeedRefreshTokenUrl(val value: String) {
         Logout("/auth/logout"),
         User("/auth/user"),
+        Token("/auth/token/reissue")
     }
 
 }

--- a/domain/src/main/java/com/dev/playground/domain/repository/AuthRepository.kt
+++ b/domain/src/main/java/com/dev/playground/domain/repository/AuthRepository.kt
@@ -13,4 +13,6 @@ interface AuthRepository {
 
     suspend fun postLogout()
 
+    suspend fun refreshAccessToken(): String
+
 }

--- a/presentation/src/main/java/com/dev/playground/presentation/base/BaseViewModel.kt
+++ b/presentation/src/main/java/com/dev/playground/presentation/base/BaseViewModel.kt
@@ -2,7 +2,9 @@ package com.dev.playground.presentation.base
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.dev.playground.domain.exception.NotLoggedInException
 import com.dev.playground.presentation.model.base.UiEffect
+import com.dev.playground.presentation.model.base.UiEffect.*
 import com.dev.playground.presentation.model.base.UiEvent
 import com.dev.playground.presentation.model.base.UiState
 import kotlinx.coroutines.channels.Channel
@@ -56,6 +58,15 @@ abstract class BaseViewModel<State : UiState, Event : UiEvent, Effect : UiEffect
     protected fun setEffect(builder: () -> Effect) {
         val effectValue = builder()
         viewModelScope.launch { _effect.send(effectValue) }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    protected fun Throwable.catchAuth(another: () -> Unit) {
+        if (this is NotLoggedInException) {
+            setEffect { RouteLoginPage as Effect }
+        } else {
+            another.invoke()
+        }
     }
 
 }

--- a/presentation/src/main/java/com/dev/playground/presentation/di/ViewModelModule.kt
+++ b/presentation/src/main/java/com/dev/playground/presentation/di/ViewModelModule.kt
@@ -3,6 +3,7 @@ package com.dev.playground.presentation.di
 import com.dev.playground.presentation.ui.add.AddMemoryViewModel
 import com.dev.playground.presentation.ui.feed.FeedViewModel
 import com.dev.playground.presentation.ui.login.LoginViewModel
+import com.dev.playground.presentation.ui.main.MainViewModel
 import com.dev.playground.presentation.ui.setting.SettingViewModel
 import com.dev.playground.presentation.ui.splash.SplashViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
@@ -38,4 +39,5 @@ val viewModelModule = module {
             requestLogoutUseCase = get()
         )
     }
+    viewModel { MainViewModel() }
 }

--- a/presentation/src/main/java/com/dev/playground/presentation/model/base/UiEffect.kt
+++ b/presentation/src/main/java/com/dev/playground/presentation/model/base/UiEffect.kt
@@ -1,3 +1,9 @@
 package com.dev.playground.presentation.model.base
 
-interface UiEffect
+import androidx.annotation.StringRes
+import com.dev.playground.presentation.R
+
+interface UiEffect {
+    abstract class AuthEffect(@StringRes val message: Int) : UiEffect
+    object RouteLoginPage: AuthEffect(R.string.please_re_log_in)
+}

--- a/presentation/src/main/java/com/dev/playground/presentation/ui/add/AddMemoryActivity.kt
+++ b/presentation/src/main/java/com/dev/playground/presentation/ui/add/AddMemoryActivity.kt
@@ -18,9 +18,10 @@ import com.dev.playground.presentation.base.SimpleBindingAdapter
 import com.dev.playground.presentation.base.SimpleBindingViewHolder
 import com.dev.playground.presentation.databinding.ActivityAddMemoryBinding
 import com.dev.playground.presentation.model.PhotoUIModel
+import com.dev.playground.presentation.ui.add.AddMemoryContract.*
 import com.dev.playground.presentation.ui.add.AddMemoryContract.AddMemoryState.Empty
 import com.dev.playground.presentation.ui.add.AddMemoryContract.AddMemoryState.SelectedPhoto
-import com.dev.playground.presentation.ui.add.AddMemoryContract.Effect.Dropped
+import com.dev.playground.presentation.ui.add.AddMemoryContract.Effect.*
 import com.dev.playground.presentation.ui.add.AddMemoryContract.Effect.ShowToast.*
 import com.dev.playground.presentation.ui.add.AddMemoryContract.Event.OnClickDrop
 import com.dev.playground.presentation.util.*
@@ -114,9 +115,7 @@ class AddMemoryActivity : BaseActivity<ActivityAddMemoryBinding>(R.layout.activi
                 effect.collect {
                     when (it) {
                         Dropped -> finish()
-                        FailUpload -> showToast(getString(R.string.add_memory_fail_upload))
-                        NotSelectPhoto -> showToast(getString(R.string.add_memory_not_select_photo))
-                        EmptyLocation -> showToast(getString(R.string.add_memory_missing_locate_information))
+                        is ShowToast -> showToast(it.message)
                     }
                 }
             }

--- a/presentation/src/main/java/com/dev/playground/presentation/ui/add/AddMemoryContract.kt
+++ b/presentation/src/main/java/com/dev/playground/presentation/ui/add/AddMemoryContract.kt
@@ -1,6 +1,8 @@
 package com.dev.playground.presentation.ui.add
 
+import androidx.annotation.StringRes
 import com.dev.playground.domain.model.Memory
+import com.dev.playground.presentation.R
 import com.dev.playground.presentation.model.base.UiEffect
 import com.dev.playground.presentation.model.base.UiEvent
 import com.dev.playground.presentation.model.base.UiState
@@ -44,10 +46,10 @@ class AddMemoryContract {
 
     sealed interface Effect : UiEffect {
         object Dropped : Effect
-        sealed interface ShowToast : Effect {
-            object FailUpload : ShowToast
-            object NotSelectPhoto : ShowToast
-            object EmptyLocation : ShowToast
+        sealed class ShowToast(@StringRes val message: Int) : Effect {
+            object FailUpload : ShowToast(R.string.add_memory_fail_upload)
+            object NotSelectPhoto : ShowToast(R.string.add_memory_not_select_photo)
+            object EmptyLocation : ShowToast(R.string.add_memory_missing_locate_information)
         }
     }
 

--- a/presentation/src/main/java/com/dev/playground/presentation/ui/feed/FeedFragment.kt
+++ b/presentation/src/main/java/com/dev/playground/presentation/ui/feed/FeedFragment.kt
@@ -7,16 +7,13 @@ import com.dev.playground.presentation.base.BaseFragment
 import com.dev.playground.presentation.base.ScrollableScreen
 import com.dev.playground.presentation.base.SimpleBindingAdapter
 import com.dev.playground.presentation.databinding.FragmentFeedBinding
-import com.dev.playground.presentation.model.base.UiEffect
-import com.dev.playground.presentation.model.base.UiEffect.*
+import com.dev.playground.presentation.model.base.UiEffect.RouteLoginPage
 import com.dev.playground.presentation.ui.dialog.DropDialog
 import com.dev.playground.presentation.ui.dialog.show
 import com.dev.playground.presentation.ui.feed.FeedContract.Effect.RouteEditPage
 import com.dev.playground.presentation.ui.feed.FeedContract.Effect.ShowRemoveDialog
 import com.dev.playground.presentation.ui.feed.FeedContract.Event.OnClickDeleteMemory
 import com.dev.playground.presentation.ui.feed.FeedContract.State.Success
-import com.dev.playground.presentation.ui.login.KakaoLoginManager
-import com.dev.playground.presentation.ui.login.LoginManager
 import com.dev.playground.presentation.ui.main.MainViewModel
 import com.dev.playground.presentation.util.repeatOnLifecycleState
 import com.dev.playground.presentation.util.showToast
@@ -64,7 +61,7 @@ class FeedFragment : BaseFragment<FragmentFeedBinding>(R.layout.fragment_feed), 
                 uiState.collect { state ->
                     when (state) {
                         is Success -> feedAdapter.submitList(state.itemList) {
-                            scrollTop()
+                            binding.rvFeed.scrollToPosition(0)
                         }
                         else -> Unit
                     }

--- a/presentation/src/main/java/com/dev/playground/presentation/ui/feed/FeedFragment.kt
+++ b/presentation/src/main/java/com/dev/playground/presentation/ui/feed/FeedFragment.kt
@@ -7,14 +7,21 @@ import com.dev.playground.presentation.base.BaseFragment
 import com.dev.playground.presentation.base.ScrollableScreen
 import com.dev.playground.presentation.base.SimpleBindingAdapter
 import com.dev.playground.presentation.databinding.FragmentFeedBinding
+import com.dev.playground.presentation.model.base.UiEffect
+import com.dev.playground.presentation.model.base.UiEffect.*
 import com.dev.playground.presentation.ui.dialog.DropDialog
 import com.dev.playground.presentation.ui.dialog.show
 import com.dev.playground.presentation.ui.feed.FeedContract.Effect.RouteEditPage
 import com.dev.playground.presentation.ui.feed.FeedContract.Effect.ShowRemoveDialog
 import com.dev.playground.presentation.ui.feed.FeedContract.Event.OnClickDeleteMemory
 import com.dev.playground.presentation.ui.feed.FeedContract.State.Success
+import com.dev.playground.presentation.ui.login.KakaoLoginManager
+import com.dev.playground.presentation.ui.login.LoginManager
+import com.dev.playground.presentation.ui.main.MainViewModel
 import com.dev.playground.presentation.util.repeatOnLifecycleState
+import com.dev.playground.presentation.util.showToast
 import kotlinx.coroutines.launch
+import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class FeedFragment : BaseFragment<FragmentFeedBinding>(R.layout.fragment_feed), ScrollableScreen {
@@ -26,6 +33,7 @@ class FeedFragment : BaseFragment<FragmentFeedBinding>(R.layout.fragment_feed), 
     }
 
     private val viewModel by viewModel<FeedViewModel>()
+    private val sharedViewModel by sharedViewModel<MainViewModel>()
     private val feedAdapter by lazy {
         SimpleBindingAdapter(FeedViewHolder::class.java)
     }
@@ -77,6 +85,10 @@ class FeedFragment : BaseFragment<FragmentFeedBinding>(R.layout.fragment_feed), 
                                     setEvent(OnClickDeleteMemory(it.id))
                                 }
                             }
+                        }
+                        is RouteLoginPage -> {
+                            context?.showToast(it.message)
+                            sharedViewModel.routeLoginPage()
                         }
                     }
                 }

--- a/presentation/src/main/java/com/dev/playground/presentation/ui/feed/FeedViewModel.kt
+++ b/presentation/src/main/java/com/dev/playground/presentation/ui/feed/FeedViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.dev.playground.domain.usecase.memory.DeleteMemoryUseCase
 import com.dev.playground.domain.usecase.memory.GetMemoryListUseCase
 import com.dev.playground.presentation.base.BaseViewModel
+import com.dev.playground.presentation.model.base.UiEffect
 import com.dev.playground.presentation.model.toPresentation
 import com.dev.playground.presentation.ui.feed.FeedContract.*
 import com.dev.playground.presentation.ui.feed.FeedContract.Effect.RouteEditPage
@@ -11,12 +12,15 @@ import com.dev.playground.presentation.ui.feed.FeedContract.Effect.ShowRemoveDia
 import com.dev.playground.presentation.ui.feed.FeedContract.Event.OnClickEdit
 import com.dev.playground.presentation.ui.feed.FeedContract.Event.OnClickRemove
 import com.dev.playground.presentation.ui.feed.FeedContract.State.*
+import com.dev.playground.presentation.ui.setting.SettingContract
 import kotlinx.coroutines.launch
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 class FeedViewModel(
     private val getMemoryListUseCase: GetMemoryListUseCase,
     private val deleteMemoryUseCase: DeleteMemoryUseCase,
-) : BaseViewModel<State, Event, Effect>(Loading) {
+) : BaseViewModel<State, Event, UiEffect>(Loading) {
 
     init {
         fetch()
@@ -41,8 +45,10 @@ class FeedViewModel(
                     )
                 }
             }.onFailure {
-                setState {
-                    Failure(it)
+                it.catchAuth {
+                    setState {
+                        Failure(it)
+                    }
                 }
             }
         }

--- a/presentation/src/main/java/com/dev/playground/presentation/ui/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/dev/playground/presentation/ui/login/LoginActivity.kt
@@ -1,6 +1,5 @@
 package com.dev.playground.presentation.ui.login
 
-import android.content.Intent
 import android.os.Bundle
 import com.dev.playground.presentation.R
 import com.dev.playground.presentation.base.BaseActivity

--- a/presentation/src/main/java/com/dev/playground/presentation/ui/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/dev/playground/presentation/ui/login/LoginViewModel.kt
@@ -6,7 +6,8 @@ import com.dev.playground.domain.model.type.LoginType
 import com.dev.playground.domain.usecase.user.login.RequestLoginUseCase
 import com.dev.playground.presentation.base.BaseViewModel
 import com.dev.playground.presentation.ui.login.LoginContract.*
-import com.dev.playground.presentation.ui.login.LoginContract.Effect.*
+import com.dev.playground.presentation.ui.login.LoginContract.Effect.RouteMainPage
+import com.dev.playground.presentation.ui.login.LoginContract.Effect.ShowFailRequestLoginToast
 import com.dev.playground.presentation.ui.login.LoginContract.Event.OnSnsLoginComplete
 import com.dev.playground.presentation.ui.login.LoginContract.State.Initialize
 import kotlinx.coroutines.launch

--- a/presentation/src/main/java/com/dev/playground/presentation/ui/main/MainActivity.kt
+++ b/presentation/src/main/java/com/dev/playground/presentation/ui/main/MainActivity.kt
@@ -8,16 +8,28 @@ import com.dev.playground.presentation.base.ScrollableScreen
 import com.dev.playground.presentation.databinding.ActivityMainBinding
 import com.dev.playground.presentation.extension.hideKeyboard
 import com.dev.playground.presentation.ui.feed.FeedFragment
+import com.dev.playground.presentation.ui.login.KakaoLoginManager
+import com.dev.playground.presentation.ui.login.LoginActivity
+import com.dev.playground.presentation.ui.login.LoginManager
 import com.dev.playground.presentation.ui.map_container.MapContainerFragment
 import com.dev.playground.presentation.ui.setting.SettingFragment
+import com.dev.playground.presentation.util.repeatOnLifecycleState
+import com.dev.playground.presentation.util.startActivity
 import com.google.android.material.navigation.NavigationBarView
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
     NavigationBarView.OnItemSelectedListener {
 
+    private val viewModel by viewModel<MainViewModel>()
+    private val loginManager: LoginManager = KakaoLoginManager()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         initViews()
+        initCollects()
     }
 
     override fun onNavigationItemSelected(item: MenuItem): Boolean {
@@ -38,6 +50,20 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main),
     private fun initViews() = with(binding) {
         bottomNavMain.setOnItemSelectedListener(this@MainActivity)
         bottomNavMain.selectedItemId = R.id.menu_feed
+    }
+
+    private fun initCollects() = with(viewModel) {
+        repeatOnLifecycleState {
+            launch {
+                routeLoginPageEffect.collectLatest {
+                    loginManager.logout {
+                        // no-op
+                    }
+                    startActivity<LoginActivity> { }
+                    finish()
+                }
+            }
+        }
     }
 
     private fun scrollTop(id: Int) {

--- a/presentation/src/main/java/com/dev/playground/presentation/ui/main/MainViewModel.kt
+++ b/presentation/src/main/java/com/dev/playground/presentation/ui/main/MainViewModel.kt
@@ -1,0 +1,20 @@
+package com.dev.playground.presentation.ui.main
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+
+class MainViewModel: ViewModel() {
+
+    private val _routeLoginPageEffect: Channel<Unit> = Channel()
+    val routeLoginPageEffect = _routeLoginPageEffect.receiveAsFlow()
+
+    fun routeLoginPage() {
+        viewModelScope.launch {
+            _routeLoginPageEffect.send(Unit)
+        }
+    }
+
+}

--- a/presentation/src/main/java/com/dev/playground/presentation/ui/setting/SettingContract.kt
+++ b/presentation/src/main/java/com/dev/playground/presentation/ui/setting/SettingContract.kt
@@ -1,6 +1,7 @@
 package com.dev.playground.presentation.ui.setting
 
 import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import com.dev.playground.domain.model.type.LoginType
 import com.dev.playground.presentation.R
 import com.dev.playground.presentation.model.base.UiEffect
@@ -42,11 +43,12 @@ class SettingContract {
     }
 
     sealed interface Effect : UiEffect {
-        object RouteLoginPage : Effect
-        sealed interface ShowToast : Effect {
-            object FailLoadUserInformation : Effect
-            object FailLogout : Effect
-            object FailSignOut : Effect
+        object SuccessLogout: UiEffect.AuthEffect(R.string.logged_out)
+        object SuccessSignOut: UiEffect.AuthEffect(R.string.sign_out)
+        sealed class ShowToast(@StringRes val message: Int) : Effect {
+            object FailLoadUserInformation : ShowToast(R.string.setting_failure_load_user_information)
+            object FailLogout : ShowToast(R.string.setting_failure_logout_please_retry)
+            object FailSignOut : ShowToast(R.string.setting_failure_sign_out_please_retry)
         }
     }
 

--- a/presentation/src/main/java/com/dev/playground/presentation/ui/setting/SettingFragment.kt
+++ b/presentation/src/main/java/com/dev/playground/presentation/ui/setting/SettingFragment.kt
@@ -1,27 +1,28 @@
 package com.dev.playground.presentation.ui.setting
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import com.charlezz.pickle.util.ext.showToast
 import com.dev.playground.presentation.R
 import com.dev.playground.presentation.base.BaseFragment
 import com.dev.playground.presentation.base.ScrollableScreen
 import com.dev.playground.presentation.databinding.FragmentSettingBinding
+import com.dev.playground.presentation.model.base.UiEffect
 import com.dev.playground.presentation.ui.dialog.DropDialog
 import com.dev.playground.presentation.ui.dialog.show
 import com.dev.playground.presentation.ui.login.KakaoLoginManager
 import com.dev.playground.presentation.ui.login.LoginActivity
 import com.dev.playground.presentation.ui.login.LoginManager
-import com.dev.playground.presentation.ui.setting.SettingContract.Effect.RouteLoginPage
-import com.dev.playground.presentation.ui.setting.SettingContract.Effect.ShowToast
+import com.dev.playground.presentation.ui.main.MainViewModel
+import com.dev.playground.presentation.ui.setting.SettingContract.Effect.*
 import com.dev.playground.presentation.ui.setting.SettingContract.Event.OnLogout
 import com.dev.playground.presentation.ui.setting.SettingContract.Event.OnSignOut
 import com.dev.playground.presentation.util.VERSION_NAME
 import com.dev.playground.presentation.util.repeatOnLifecycleState
+import com.dev.playground.presentation.util.showToast
 import com.dev.playground.presentation.util.startActivity
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
+import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.qualifier.named
 
@@ -33,6 +34,7 @@ class SettingFragment : BaseFragment<FragmentSettingBinding>(R.layout.fragment_s
     }
 
     private val viewModel by viewModel<SettingViewModel>()
+    private val sharedViewModel by sharedViewModel<MainViewModel>()
     private val versionNumber: String by inject(named(VERSION_NAME))
     private val loginManager: LoginManager = KakaoLoginManager()
 
@@ -45,10 +47,10 @@ class SettingFragment : BaseFragment<FragmentSettingBinding>(R.layout.fragment_s
     private fun initViews() = with(binding) {
         vm = viewModel
         tvServiceTerms.setOnClickListener {
-            showToast("TODO : 서비스 이용약관 WebView 표시!")
+            context?.showToast("TODO : 서비스 이용약관 WebView 표시!")
         }
         tvPrivateTerms.setOnClickListener {
-            showToast("TODO : 개인정보 취급방침 WebView 표시!")
+            context?.showToast("TODO : 개인정보 취급방침 WebView 표시!")
         }
         tvCurrentVersion.text = versionNumber
         tvLogout.setOnClickListener {
@@ -73,19 +75,11 @@ class SettingFragment : BaseFragment<FragmentSettingBinding>(R.layout.fragment_s
             launch {
                 effect.collect {
                     when (it) {
-                        RouteLoginPage -> {
-                            loginManager.logout {
-                                // no-op
-                            }
-                            showToast(getString(R.string.logged_out))
-                            activity?.let { a ->
-                                a.startActivity<LoginActivity> { }
-                                a.finish()
-                            }
+                        is UiEffect.AuthEffect -> {
+                            context?.showToast(it.message)
+                            sharedViewModel.routeLoginPage()
                         }
-                        ShowToast.FailLoadUserInformation -> showToast(getString(R.string.setting_failure_load_user_information))
-                        ShowToast.FailLogout -> showToast(getString(R.string.setting_failure_logout_please_retry))
-                        ShowToast.FailSignOut -> showToast(getString(R.string.setting_failure_sign_out_please_retry))
+                        is ShowToast -> context?.showToast(it.message)
                     }
                 }
             }

--- a/presentation/src/main/java/com/dev/playground/presentation/ui/setting/SettingViewModel.kt
+++ b/presentation/src/main/java/com/dev/playground/presentation/ui/setting/SettingViewModel.kt
@@ -6,8 +6,8 @@ import com.dev.playground.domain.usecase.user.GetUserEmailUseCase
 import com.dev.playground.domain.usecase.user.login.GetLoginTypeUseCase
 import com.dev.playground.domain.usecase.user.login.RequestLogoutUseCase
 import com.dev.playground.presentation.base.BaseViewModel
+import com.dev.playground.presentation.model.base.UiEffect
 import com.dev.playground.presentation.ui.setting.SettingContract.*
-import com.dev.playground.presentation.ui.setting.SettingContract.Effect.RouteLoginPage
 import com.dev.playground.presentation.ui.setting.SettingContract.Effect.ShowToast
 import com.dev.playground.presentation.ui.setting.SettingContract.Event.OnLogout
 import com.dev.playground.presentation.ui.setting.SettingContract.Event.OnSignOut
@@ -23,7 +23,7 @@ class SettingViewModel(
     private val deleteUserUseCase: DeleteUserUseCase,
     private val getLoginTypeUseCase: GetLoginTypeUseCase,
     private val requestLogoutUseCase: RequestLogoutUseCase,
-) : BaseViewModel<State, Event, Effect>(Idle) {
+) : BaseViewModel<State, Event, UiEffect>(Idle) {
 
     init {
         loadUserInformation()
@@ -38,9 +38,9 @@ class SettingViewModel(
                 setState {
                     Success(email = email, loginType = loginType)
                 }
-            }.catch {
-                setEffect {
-                    ShowToast.FailLoadUserInformation
+            }.catch { e ->
+                e.catchAuth {
+                    setEffect { ShowToast.FailLoadUserInformation }
                 }
             }.collect()
         }
@@ -51,11 +51,13 @@ class SettingViewModel(
             requestLogoutUseCase.invoke()
                 .onSuccess {
                     setEffect {
-                        RouteLoginPage
+                        Effect.SuccessLogout
                     }
                 }.onFailure {
-                    setEffect {
-                        ShowToast.FailLogout
+                    it.catchAuth {
+                        setEffect {
+                            ShowToast.FailLogout
+                        }
                     }
                 }
         }
@@ -66,12 +68,14 @@ class SettingViewModel(
             deleteUserUseCase.invoke()
                 .onSuccess {
                     setEffect {
-                        RouteLoginPage
+                        Effect.SuccessSignOut
                     }
                 }
                 .onFailure {
-                    setEffect {
-                        ShowToast.FailSignOut
+                    it.catchAuth {
+                        setEffect {
+                            ShowToast.FailSignOut
+                        }
                     }
                 }
         }

--- a/presentation/src/main/java/com/dev/playground/presentation/ui/splash/SplashActivity.kt
+++ b/presentation/src/main/java/com/dev/playground/presentation/ui/splash/SplashActivity.kt
@@ -3,10 +3,10 @@ package com.dev.playground.presentation.ui.splash
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.dev.playground.presentation.R
+import com.dev.playground.presentation.model.base.UiEffect.RouteLoginPage
 import com.dev.playground.presentation.ui.login.LoginActivity
 import com.dev.playground.presentation.ui.main.MainActivity
-import com.dev.playground.presentation.ui.splash.SplashViewModel.SplashState.Failure
-import com.dev.playground.presentation.ui.splash.SplashViewModel.SplashState.Success
+import com.dev.playground.presentation.ui.splash.SplashContract.Effect.RouteMainPage
 import com.dev.playground.presentation.util.repeatOnLifecycleState
 import com.dev.playground.presentation.util.startActivity
 import kotlinx.coroutines.launch
@@ -20,23 +20,21 @@ class SplashActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         setContentView(R.layout.activity_splash)
-
-        viewModel.checkLoginStatus()
         initCollects()
     }
 
     private fun initCollects() = with(viewModel) {
         repeatOnLifecycleState {
             launch {
-                splashState.collect { uiState ->
-                    when (uiState) {
-                        is Success -> startActivity<MainActivity> { }
-                        is Failure -> startActivity<LoginActivity> { }
-                        else -> println("로딩중")
+                effect.collect {
+                    when (it) {
+                        RouteMainPage -> startActivity<MainActivity> { }
+                        RouteLoginPage -> startActivity<LoginActivity> { }
                     }
                     finish()
                 }
             }
         }
     }
+
 }

--- a/presentation/src/main/java/com/dev/playground/presentation/ui/splash/SplashContract.kt
+++ b/presentation/src/main/java/com/dev/playground/presentation/ui/splash/SplashContract.kt
@@ -1,0 +1,19 @@
+package com.dev.playground.presentation.ui.splash
+
+import com.dev.playground.presentation.model.base.UiEffect
+import com.dev.playground.presentation.model.base.UiEvent
+import com.dev.playground.presentation.model.base.UiState
+
+class SplashContract {
+
+    sealed interface State: UiState {
+        object Idle: State
+    }
+
+    sealed interface Event: UiEvent
+
+    sealed interface Effect: UiEffect {
+        object RouteMainPage: Effect
+    }
+
+}

--- a/presentation/src/main/java/com/dev/playground/presentation/ui/splash/SplashViewModel.kt
+++ b/presentation/src/main/java/com/dev/playground/presentation/ui/splash/SplashViewModel.kt
@@ -1,42 +1,42 @@
 package com.dev.playground.presentation.ui.splash
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.dev.playground.domain.model.Token
 import com.dev.playground.domain.usecase.user.login.GetTokenUseCase
-import com.dev.playground.presentation.ui.splash.SplashViewModel.SplashState.*
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
+import com.dev.playground.presentation.base.BaseViewModel
+import com.dev.playground.presentation.model.base.UiEffect
+import com.dev.playground.presentation.model.base.UiEffect.RouteLoginPage
+import com.dev.playground.presentation.ui.splash.SplashContract.Effect.RouteMainPage
+import com.dev.playground.presentation.ui.splash.SplashContract.Event
+import com.dev.playground.presentation.ui.splash.SplashContract.State
+import com.dev.playground.presentation.ui.splash.SplashContract.State.Idle
 import kotlinx.coroutines.launch
 
 class SplashViewModel(
-    private val getTokenUseCase: GetTokenUseCase
-) : ViewModel() {
+    private val getTokenUseCase: GetTokenUseCase,
+) : BaseViewModel<State, Event, UiEffect>(Idle) {
 
-    private val _splashState: MutableStateFlow<SplashState> = MutableStateFlow(
-        Loading
-    )
-    val splashState: StateFlow<SplashState> = _splashState.asStateFlow()
+    init {
+        checkHasToken()
+    }
 
-    fun checkLoginStatus() {
+    private fun checkHasToken() {
         viewModelScope.launch {
             val result = getTokenUseCase.invoke()
 
-            result
-                .onSuccess { auth ->
-                    _splashState.update { Success(auth) }
-                }.onFailure { throwable ->
-                    _splashState.update { Failure(throwable) }
+            result.onSuccess {
+                setEffect {
+                    RouteMainPage
                 }
+            }.onFailure {
+                setEffect {
+                    RouteLoginPage
+                }
+            }
         }
     }
 
-    sealed class SplashState {
-        data class Success(val data: Token) : SplashState()
-        data class Failure(val error: Throwable) : SplashState()
-        object Loading : SplashState()
+    override fun handleEvent(event: Event) {
+        // no-op
     }
 
 }

--- a/presentation/src/main/java/com/dev/playground/presentation/util/ContextExt.kt
+++ b/presentation/src/main/java/com/dev/playground/presentation/util/ContextExt.kt
@@ -3,6 +3,7 @@ package com.dev.playground.presentation.util
 import android.content.Context
 import android.content.Intent
 import android.widget.Toast
+import androidx.annotation.StringRes
 
 inline fun <reified T> Context.startActivity(noinline action: Intent.() -> Unit) {
     startActivity(Intent(this, T::class.java).apply(action))
@@ -10,4 +11,8 @@ inline fun <reified T> Context.startActivity(noinline action: Intent.() -> Unit)
 
 fun Context.showToast(message: String?, duration: Int = Toast.LENGTH_SHORT) {
     Toast.makeText(this, message, duration).show()
+}
+
+fun Context.showToast(@StringRes messageRes: Int) {
+    showToast(getString(messageRes))
 }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -19,6 +19,8 @@
     <string name="failure_kakao_login">카카오 로그인에 실패했습니다.</string>
     <string name="failure_request_login">로그인에 실패했습니다.</string>
     <string name="logged_out">로그아웃 되었습니다.</string>
+    <string name="sign_out">회원탈퇴 되었습니다.</string>
+    <string name="please_re_log_in">재로그인이 필요합니다.</string>
 
     <string name="menu_title_feed">Feed</string>
     <string name="menu_title_map">Map</string>


### PR DESCRIPTION
## What?
- 액세스 토큰 만료 시 재발급 및 로그아웃 처리

## Changes
- `AuthTokenRefresher` 구현 (api call 시 auth 관련 에러 발생하면 토큰 연장 및 retry)
- 액세스 토큰 리프레시 api 구현
- `MainActivity`의 `ViewModel` 공유하여 로그아웃 처리 
- 피드화면 새로고침 이후 맨 위로 스크롤되어 있는지 확인
- #23 

## Test Guide
- 빌드 -> 로그인 -> 액세스 토큰 만료된 이후 -> 토큰 리프레시 후 다시 call 처리되는지 확인

<img width="714" alt="image" src="https://user-images.githubusercontent.com/40753104/209656277-5422773b-9a18-4e8f-81fc-739e18e5f595.png">


## ⚠️ Warning
